### PR TITLE
add JSON.parse to setHistory(res.history)

### DIFF
--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -54,7 +54,7 @@ function AppRender({appData, history, setHistory, players, setPlayers, isLoading
         return createGame()
         .then(res => {
             setGameId(res.id)
-            setHistory(res.history)
+            setHistory(JSON.parse(res.history))
             setIsPlaying(true)
             navigate(`/games/${res.id}`)
         })
@@ -64,7 +64,7 @@ function AppRender({appData, history, setHistory, players, setPlayers, isLoading
         return getGame(gameId)
         .then(res => {
             setGameId(res.id)
-            setHistory(res.history)
+            setHistory(JSON.parse(res.history))
             setIsPlaying(true)
             navigate(`/games/${gameId}`)
         })

--- a/src/Components/Home.jsx
+++ b/src/Components/Home.jsx
@@ -7,7 +7,7 @@ function Home({history, setHistory, gameId, setGameId, isLoading, setIsLoading, 
 	useEffect(() => {
 		getGame(1)
 		.then(res => {
-			setHistory(res.history)
+			setHistory(JSON.parse(res.history))
 			setGameId(res.id)
 		})
 	}, [])


### PR DESCRIPTION
It looks like for some reason the data being saved in the db is being saved as a String. When I debugged this I traced it from `App.jsx` and simply logged `res.history` from the `useEffect`. This looked good, but the display was bugging out. So I dug a little deeper. I decided to try and log history inside of `AppRender`, very first line in the function. This is when it got strange. Came back with two logs. One of them the Object version of `history`. The second was the literal String `[[null, null, null, null, null, null, null, null, null]]` which was SO strange. Turns out, we've got two `useEffects` with empty dependency arrays. This is precisely why it's a best practice to have any empty dependency array `useEffects` happening first thing inside of `App.jsx` as to not cause any confusion. So, with two of these happening one of them is fetching `/core` and setting history as expected. The other is requesting from `/game/1` and setting the String version. A best practice when dealing with data to and from API's is to `JSON.stringify` the `body` part of the Request and then `JSON.parse` the Response. This is because the API is saving the results of `history` as a string in the database and simply returning whatever is saved in the DB, expecting the frontend to handle formatting or parsing the data.